### PR TITLE
fix: use runtime pool capacity from config

### DIFF
--- a/djpm/run/runner.go
+++ b/djpm/run/runner.go
@@ -14,15 +14,6 @@ import (
 	"github.com/artela-network/aspect-core/types"
 )
 
-var vmPool *runtime.RuntimePool
-
-func RuntimePool() *runtime.RuntimePool {
-	if vmPool == nil {
-		vmPool = runtime.NewRuntimePool(10)
-	}
-	return vmPool
-}
-
 type Runner struct {
 	vmKey string
 	vm    runtime.AspectRuntime
@@ -34,7 +25,7 @@ type Runner struct {
 func NewRunner(aspID string, code []byte) (*Runner, error) {
 	aspectId := common.HexToAddress(aspID)
 	register := api.NewRegister(&aspectId)
-	key, vm, err := RuntimePool().Runtime(runtime.WASM, code, register.HostApis())
+	key, vm, err := types.RuntimePool().Runtime(runtime.WASM, code, register.HostApis())
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +38,7 @@ func NewRunner(aspID string, code []byte) (*Runner, error) {
 }
 
 func (r *Runner) Return() {
-	RuntimePool().Return(r.vmKey, r.vm)
+	types.RuntimePool().Return(r.vmKey, r.vm)
 }
 
 func (r *Runner) JoinPoint(name types.PointCut, gas uint64, blockNumber int64, contractAddr *common.Address, txRequest proto.Message) (*types.AspectResponse, error) {

--- a/djpm/run/runner.go
+++ b/djpm/run/runner.go
@@ -25,7 +25,7 @@ type Runner struct {
 func NewRunner(aspID string, code []byte) (*Runner, error) {
 	aspectId := common.HexToAddress(aspID)
 	register := api.NewRegister(&aspectId)
-	key, vm, err := types.RuntimePool().Runtime(runtime.WASM, code, register.HostApis())
+	key, vm, err := types.Runtime(code, register.HostApis())
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func NewRunner(aspID string, code []byte) (*Runner, error) {
 }
 
 func (r *Runner) Return() {
-	types.RuntimePool().Return(r.vmKey, r.vm)
+	types.ReturnRuntime(r.vmKey, r.vm)
 }
 
 func (r *Runner) JoinPoint(name types.PointCut, gas uint64, blockNumber int64, contractAddr *common.Address, txRequest proto.Message) (*types.AspectResponse, error) {

--- a/types/runner_pool.go
+++ b/types/runner_pool.go
@@ -31,6 +31,8 @@ func Runtime(code []byte, registry *runtime.HostAPIRegistry) (string, runtime.As
 // ReturnRuntime returns the the runtime instance to the pool, is the pool is enabled.
 func ReturnRuntime(key string, instance runtime.AspectRuntime) {
 	if !enable {
+		// release the host functions and memorys in Destory
+		instance.Destroy()
 		return
 	}
 	if vmPool == nil {

--- a/types/runner_pool.go
+++ b/types/runner_pool.go
@@ -1,0 +1,18 @@
+package types
+
+import runtime "github.com/artela-network/aspect-runtime"
+
+const DefaultAspectPoolSize = 10
+
+var vmPool *runtime.RuntimePool
+
+func InitRuntimePool(capacity int32) {
+	vmPool = runtime.NewRuntimePool(int(capacity))
+}
+
+func RuntimePool() *runtime.RuntimePool {
+	if vmPool == nil {
+		InitRuntimePool(DefaultAspectPoolSize)
+	}
+	return vmPool
+}

--- a/types/runner_pool.go
+++ b/types/runner_pool.go
@@ -4,15 +4,37 @@ import runtime "github.com/artela-network/aspect-runtime"
 
 const DefaultAspectPoolSize = 10
 
-var vmPool *runtime.RuntimePool
+var (
+	enable bool
+	vmPool *runtime.RuntimePool
+)
 
+// InitRuntimePool init runtime pool with given capacity.
 func InitRuntimePool(capacity int32) {
+	enable = capacity > 0
+	if !enable {
+		return
+	}
 	vmPool = runtime.NewRuntimePool(int(capacity))
 }
 
-func RuntimePool() *runtime.RuntimePool {
+// Runtime returns a aspect-runtime instance from the pool or creating a new one.
+func Runtime(code []byte, registry *runtime.HostAPIRegistry) (string, runtime.AspectRuntime, error) {
+	if !enable {
+		vm, err := runtime.NewAspectRuntime(runtime.WASM, code, registry)
+		return "", vm, err
+	}
+
+	return vmPool.Runtime(runtime.WASM, code, registry)
+}
+
+// ReturnRuntime returns the the runtime instance to the pool, is the pool is enabled.
+func ReturnRuntime(key string, instance runtime.AspectRuntime) {
+	if !enable {
+		return
+	}
 	if vmPool == nil {
 		InitRuntimePool(DefaultAspectPoolSize)
 	}
-	return vmPool
+	vmPool.Return(key, instance)
 }


### PR DESCRIPTION
1. refactor to run aspect with pool enable or disable.
2. destory aspect-runtime instance after usage.